### PR TITLE
Delete descriptor.mod

### DIFF
--- a/descriptor.mod
+++ b/descriptor.mod
@@ -1,8 +1,0 @@
-version="1"
-picture="thumbnail.png"
-tags={
-	"Alternative History"
-}
-name="Very-Very Unhistorical"
-supported_version="1.15.3"
-remote_file_id="3058842601"


### PR DESCRIPTION
Deleting the descriptor to prevent issues with accidentally deleting our personal descriptors when testing